### PR TITLE
Fallback to `NaiveDateTime.utc_now/0` if date is invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 unzip-*.tar
 
+# Ignore elixirls
+.elixir_ls/*

--- a/lib/unzip.ex
+++ b/lib/unzip.ex
@@ -296,9 +296,13 @@ defmodule Unzip do
     end
   end
 
-  defp to_datetime(<<year::7, month::4, day::5>>, <<hour::5, minute::6, second::5>>) do
-    {:ok, datetime} = NaiveDateTime.new(1980 + year, month, day, hour, minute, second * 2)
-    datetime
+  defp to_datetime(<<year::7, month::4, day::5>> = date, <<hour::5, minute::6, second::5>> = time) do
+    case NaiveDateTime.new(1980 + year, month, day, hour, minute, second * 2) do
+      {:ok, datetime}  -> datetime
+       _ ->
+        Logger.info("Unable to create datetime from: date: #{inspect(date)} time: #{inspect(time)}")
+        nil
+    end
   end
 
   defp pread!(file, offset, length) do


### PR DESCRIPTION
I've encountered zip archives where the day and month in the header are `0`, which prevents inflation.