### PR TITLE
function decompress(stream, 0x8) was improved

### DIFF
--- a/lib/unzip.ex
+++ b/lib/unzip.ex
@@ -142,7 +142,7 @@ defmodule Unzip do
         end
       end,
       fn {z, _flag} ->
-        :zlib.inflateReset(z)
+        :zlib.inflateEnd(z)
         :zlib.close(z)
       end
     )


### PR DESCRIPTION
I have found a bug in the function decompress(stream, 0x8),  some zip archive was unpack incorrect,
I have improved it.