### PR TITLE
Adds a @type definition for the %Unzip{} struct

### DIFF
--- a/lib/unzip.ex
+++ b/lib/unzip.ex
@@ -30,6 +30,11 @@ defmodule Unzip do
 
   @chunk_size 65_000
 
+  @type t :: %__MODULE__{
+          cd_list: %{optional(String.t()) => map()},
+          zip: struct()
+        }
+
   defstruct [:zip, :cd_list]
 
   defmodule Error do


### PR DESCRIPTION
This PR adds a `@type` definition  for the `%Unzip{}` struct.
This addresses https://github.com/akash-akya/unzip/issues/13